### PR TITLE
force reloading the saved states when the settings is shown

### DIFF
--- a/iNDS/iNDSGameTableView.m
+++ b/iNDS/iNDSGameTableView.m
@@ -21,6 +21,8 @@
 {
     [super viewDidLoad];
     self.navigationItem.title = _game.gameTitle;
+    
+    [[AppDelegate sharedInstance].currentEmulatorViewController.settingsContainer addObserver:self forKeyPath:@"hidden" options:NSKeyValueObservingOptionNew context:nil];
 }
 
 -(void) viewWillAppear:(BOOL)animated
@@ -28,6 +30,20 @@
     [super viewWillAppear:animated];
     [self.tableView reloadData];
     
+}
+
+- (void)dealloc
+{
+    [[AppDelegate sharedInstance].currentEmulatorViewController.settingsContainer removeObserver:self forKeyPath:@"hidden" context:nil];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context
+{
+    if (object == [AppDelegate sharedInstance].currentEmulatorViewController.settingsContainer) {
+        if ([change[NSKeyValueChangeNewKey] isEqual:@(NO)]) {
+            [self.tableView reloadData];
+        }
+    }
 }
 
 #pragma mark - Table View


### PR DESCRIPTION
When the games starts from a saved state which also happens to be on top, after 3 min the auto save will take its place. However when the settings screen is brought to front, the list of states remain unchanged. This will cause a problem when loading state. This PR will fix the problem with minimum effort.
